### PR TITLE
configure.ac: fix syntax issues in coreaudio test and CFLAGS.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,14 +105,15 @@ if test "$with_coreaudio" = "no";then
     echo "Disabling coreaudio audio output support"
     have_coreaudio=no
 else
-    if test "${host_os}"="darwin";then
-        COREAUDIO_CFLAGS=-dynamiclib -fvisibility=default
-        COREAUDIO_LIBS="-framework CoreAudio -framework AudioToolbox -framework AudioUnit"
-        have_coreaudio=yes
-        AC_DEFINE(HAVE_COREAUDIO_H, [], [Do we have coreaudio?])
-    else
-        have_coreaudio=no
-    fi
+    case "${host_os}" in
+        darwin*)
+            COREAUDIO_CFLAGS='-dynamiclib -fvisibility=default'
+            COREAUDIO_LIBS="-framework CoreAudio -framework AudioToolbox -framework AudioUnit"
+            have_coreaudio=yes
+            AC_DEFINE(HAVE_COREAUDIO_H, [], [Do we have coreaudio?]);;
+        *)
+            have_coreaudio=no;;
+    esac
 fi
 
 AC_SUBST(COREAUDIO_CFLAGS)


### PR DESCRIPTION
coreaudio CFLAGS were not properly quoted.
Also the test against $host_os needed to be reworked.
test "${host_os}"=darwin is wrong in two ways:
* the operator is not surrounded by space, so it is not processed.
* $host_os may be something like darwin16.3.0.
So the test needs restructuring.