### PR TITLE
Fix audio choppiness on some systems

### DIFF
--- a/src/audio_priv.h
+++ b/src/audio_priv.h
@@ -53,8 +53,10 @@ struct audio_object
 };
 
 /* We try to aim for 10ms cancelation latency, which will be perceived as
- * "snappy" by users */
-#define LATENCY 10
+ * "snappy" by users. However, some systems (e.g. RPi) do produce chopped
+ * audio when this value is smaller than 60.
+ */
+#define LATENCY 60
 
 #if defined(_WIN32) || defined(_WIN64)
 


### PR DESCRIPTION
Commit a41d46e816d2 ("Fix cancellation snappiness") made espeak unusable
on the RaspberryPi due to extreme audio choppiness. This can sometimes
be observed on some PC-type systems as well, albeit much less
prominently.

Relax the timing to the smallest value that makes it work again on the
RaspberryPi.
