### PR TITLE
Cleanup header checks for OSS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -137,17 +137,7 @@ else
         AC_CHECK_LIB(ossaudio, _oss_ioctl)
         have_oss=yes
     ],[
-        AC_CHECK_HEADERS([linux/soundcard.h],[
-            AC_CHECK_LIB(ossaudio, _oss_ioctl)
-            have_oss=yes
-        ],[
-            AC_CHECK_HEADERS([soundcard.h],[
-                AC_CHECK_LIB(ossaudio, _oss_ioctl)
-                have_oss=yes
-            ],[
-                have_oss=no
-            ])
-        ])
+        have_oss=no
     ])
 fi
 

--- a/src/oss.c
+++ b/src/oss.c
@@ -22,24 +22,16 @@
 #include "audio_priv.h"
 
 #if defined(HAVE_SYS_SOUNDCARD_H)
+
 #include <sys/soundcard.h>
-#define DEFAULT_OSS_DEVICE "/dev/dsp"
-#elif defined(HAVE_LINUX_SOUNDCARD_H)
-#include <linux/soundcard.h>
-#define DEFAULT_OSS_DEVICE "/dev/dsp"
-#elif defined(HAVE_SOUNDCARD_H)
-#include <soundcard.h>
-#define DEFAULT_OSS_DEVICE "/dev/dsp"
-#endif
-
-#ifdef DEFAULT_OSS_DEVICE
-
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
 #include <stdio.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+
+#define DEFAULT_OSS_DEVICE "/dev/dsp"
 
 struct oss_object
 {


### PR DESCRIPTION
OpenBSD no longer uses OSS so remove the soundcard.h header check. FreeBSD / NetBSD / DragonFly / Linux all use sys/soundcard.h.