### PR TITLE
Add Sun audio support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,3 +90,9 @@ EXTRA_DIST += \
 	src/TPCircularBuffer/README.markdown \
 	src/TPCircularBuffer/TPCircularBuffer.podspec
 endif
+
+# Sun audio support
+if HAVE_SUN
+src_libpcaudio_la_SOURCES += \
+	src/sun.c
+endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -91,8 +91,8 @@ EXTRA_DIST += \
 	src/TPCircularBuffer/TPCircularBuffer.podspec
 endif
 
-# Sun audio support
-if HAVE_SUN
+# NetBSD audio support
+if HAVE_NETBSD
 src_libpcaudio_la_SOURCES += \
-	src/sun.c
+	src/netbsd.c
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,29 @@ else
 fi
 
 dnl ================================================================
+dnl Sun checks.
+dnl ================================================================
+
+AC_ARG_WITH([sun],
+    [AS_HELP_STRING([--with-sun], [support for Sun audio output @<:@default=yes@:>@])],
+    [])
+
+if test "$with_sun" = "no"; then
+    echo "Disabling Sun audio output support"
+    have_sun=no
+else
+    case $host_os in
+        *netbsd*)
+            have_sun=yes
+	    ;;
+        *)
+            have_sun=no
+            ;;
+    esac
+fi
+AM_CONDITIONAL([HAVE_SUN], [test "x${have_sun}" = "xyes"])
+
+dnl ================================================================
 dnl Generate output.
 dnl ================================================================
 
@@ -162,4 +185,5 @@ AC_MSG_NOTICE([
 	QSA support:                   ${have_qsa}
 	Coreaudio support:             ${have_coreaudio} 
 	OSS support:                   ${have_oss}
+	Sun support:                   ${have_sun}
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -142,27 +142,27 @@ else
 fi
 
 dnl ================================================================
-dnl Sun checks.
+dnl NetBSD checks.
 dnl ================================================================
 
-AC_ARG_WITH([sun],
-    [AS_HELP_STRING([--with-sun], [support for Sun audio output @<:@default=no@:>@])],
+AC_ARG_WITH([netbsd],
+    [AS_HELP_STRING([--with-netbsd], [support for NetBSD audio output @<:@default=no@:>@])],
     [])
 
-if test "$with_sun" = "no"; then
-    echo "Disabling Sun audio output support"
-    have_sun=no
+if test "$with_netbsd" = "no"; then
+    echo "Disabling NetBSD audio output support"
+    have_netbsd=no
 else
     case $host_os in
         *netbsd*)
-            have_sun=yes
+            have_netbsd=yes
 	    ;;
         *)
-            have_sun=no
+            have_netbsd=no
             ;;
     esac
 fi
-AM_CONDITIONAL([HAVE_SUN], [test "x${have_sun}" = "xyes"])
+AM_CONDITIONAL([HAVE_NETBSD], [test "x${have_netbsd}" = "xyes"])
 
 dnl ================================================================
 dnl Generate output.
@@ -185,5 +185,5 @@ AC_MSG_NOTICE([
 	QSA support:                   ${have_qsa}
 	Coreaudio support:             ${have_coreaudio} 
 	OSS support:                   ${have_oss}
-	Sun support:                   ${have_sun}
+	NetBSD support:                ${have_netbsd}
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -146,7 +146,7 @@ dnl Sun checks.
 dnl ================================================================
 
 AC_ARG_WITH([sun],
-    [AS_HELP_STRING([--with-sun], [support for Sun audio output @<:@default=yes@:>@])],
+    [AS_HELP_STRING([--with-sun], [support for Sun audio output @<:@default=no@:>@])],
     [])
 
 if test "$with_sun" = "no"; then

--- a/src/audio.c
+++ b/src/audio.c
@@ -94,7 +94,10 @@ create_audio_device_object(const char *device,
 #if defined(__APPLE__)
 	if ((object = create_coreaudio_object(device, application_name, description)) != NULL)
 		return object;
-
+#else
+#if defined(_SUNAUDIO)       
+	if ((object = create_sun_object(device, application_name, description)) != NULL)
+		return object;
 #else
 	if ((object = create_pulseaudio_object(device, application_name, description)) != NULL)
 		return object;
@@ -104,6 +107,7 @@ create_audio_device_object(const char *device,
 		return object;
 	if ((object = create_oss_object(device, application_name, description)) != NULL)
 		return object;
+#endif
 #endif
 #endif
 	return NULL;

--- a/src/audio.c
+++ b/src/audio.c
@@ -95,7 +95,7 @@ create_audio_device_object(const char *device,
 	if ((object = create_coreaudio_object(device, application_name, description)) != NULL)
 		return object;
 #else
-#if defined(_NETBSD)       
+#if defined(__NetBSD__)       
 	if ((object = create_netbsd_object(device, application_name, description)) != NULL)
 		return object;
 #else

--- a/src/audio.c
+++ b/src/audio.c
@@ -95,8 +95,8 @@ create_audio_device_object(const char *device,
 	if ((object = create_coreaudio_object(device, application_name, description)) != NULL)
 		return object;
 #else
-#if defined(_SUNAUDIO)       
-	if ((object = create_sun_object(device, application_name, description)) != NULL)
+#if defined(_NETBSD)       
+	if ((object = create_netbsd_object(device, application_name, description)) != NULL)
 		return object;
 #else
 	if ((object = create_pulseaudio_object(device, application_name, description)) != NULL)

--- a/src/audio_priv.h
+++ b/src/audio_priv.h
@@ -115,7 +115,7 @@ create_oss_object(const char *device,
                   const char *description);
 
 struct audio_object *
-create_sun_object(const char *device,
+create_netbsd_object(const char *device,
                   const char *application_name,
                   const char *description);
 

--- a/src/audio_priv.h
+++ b/src/audio_priv.h
@@ -52,8 +52,9 @@ struct audio_object
 	                         int error);
 };
 
-/* 60ms is the minimum and default buffer size used by eSpeak */
-#define LATENCY 60
+/* We try to aim for 10ms cancelation latency, which will be perceived as
+ * "snappy" by users */
+#define LATENCY 10
 
 #if defined(_WIN32) || defined(_WIN64)
 
@@ -85,6 +86,15 @@ create_xaudio2_object(const char *device,
         const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
         (type *)( (char *)__mptr - offsetof(type,member) );})
 
+#ifdef __NetBSD__
+
+struct audio_object *
+create_netbsd_object(const char *device,
+                  const char *application_name,
+                  const char *description);
+
+#else
+
 #ifdef __APPLE__
 
 struct audio_object *
@@ -114,14 +124,10 @@ create_oss_object(const char *device,
                   const char *application_name,
                   const char *description);
 
-struct audio_object *
-create_netbsd_object(const char *device,
-                  const char *application_name,
-                  const char *description);
-
 #endif
 #endif
-
+#endif
+  
 #ifdef __cplusplus
 }
 #endif

--- a/src/audio_priv.h
+++ b/src/audio_priv.h
@@ -114,6 +114,11 @@ create_oss_object(const char *device,
                   const char *application_name,
                   const char *description);
 
+struct audio_object *
+create_sun_object(const char *device,
+                  const char *application_name,
+                  const char *description);
+
 #endif
 #endif
 

--- a/src/oss.c
+++ b/src/oss.c
@@ -96,7 +96,7 @@ oss_object_close(struct audio_object *object)
 {
 	struct oss_object *self = to_oss_object(object);
 
-	if (self->fd == -1) {
+	if (self->fd != -1) {
 		close(self->fd);
 		self->fd = -1;
 	}

--- a/src/sun.c
+++ b/src/sun.c
@@ -121,7 +121,7 @@ sun_object_close(struct audio_object *object)
 {
 	struct sun_object *self = to_sun_object(object);
 
-	if (self->fd == -1) {
+	if (self-> != -1) {
 		close(self->fd);
 		self->fd = -1;
 	}

--- a/src/sun.c
+++ b/src/sun.c
@@ -1,0 +1,199 @@
+/* Sun Output.
+ *
+ * Based on Oss Output by Reece H. Dunn
+ *
+ * This file is part of pcaudiolib.
+ *
+ * pcaudiolib is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pcaudiolib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pcaudiolib.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+#include "audio_priv.h"
+
+#include <sys/audioio.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+struct sun_object
+{
+	struct audio_object vtable;
+	int fd;
+	int ctlfd;
+	char *device;
+
+};
+
+#define to_sun_object(object) container_of(object, struct sun_object, vtable)
+
+int
+sun_object_open(struct audio_object *object,
+                enum audio_object_format format,
+                uint32_t rate,
+                uint8_t channels)
+{
+	struct sun_object *self = to_sun_object(object);
+		
+	if (self->fd != -1)
+		return EEXIST;
+
+	struct aformat_sun
+	{
+		int audio_object_format;
+		int sun_format;
+		int sun_precision;
+	};
+	struct aformat_sun aformat_sun_tbl[] = {
+		{AUDIO_OBJECT_FORMAT_ALAW, AUDIO_ENCODING_ALAW, 8},
+		{AUDIO_OBJECT_FORMAT_ULAW, AUDIO_ENCODING_ULAW, 8},
+		{AUDIO_OBJECT_FORMAT_S8, AUDIO_ENCODING_SLINEAR, 8},
+		{AUDIO_OBJECT_FORMAT_U8, AUDIO_ENCODING_ULINEAR, 8},
+		{AUDIO_OBJECT_FORMAT_S16LE, AUDIO_ENCODING_SLINEAR_LE, 16},
+		{AUDIO_OBJECT_FORMAT_S16BE, AUDIO_ENCODING_SLINEAR_BE, 16},
+		{AUDIO_OBJECT_FORMAT_U16LE, AUDIO_ENCODING_ULINEAR_LE, 16},
+		{AUDIO_OBJECT_FORMAT_U16BE, AUDIO_ENCODING_ULINEAR_BE, 16},
+		{AUDIO_OBJECT_FORMAT_S18LE, AUDIO_ENCODING_SLINEAR_LE, 18},
+		{AUDIO_OBJECT_FORMAT_S18BE, AUDIO_ENCODING_SLINEAR_BE, 18},
+		{AUDIO_OBJECT_FORMAT_U18LE, AUDIO_ENCODING_ULINEAR_LE, 18},
+		{AUDIO_OBJECT_FORMAT_U18BE, AUDIO_ENCODING_ULINEAR_BE, 18},
+		{AUDIO_OBJECT_FORMAT_S20LE, AUDIO_ENCODING_SLINEAR_LE, 20},
+		{AUDIO_OBJECT_FORMAT_S20BE, AUDIO_ENCODING_SLINEAR_BE, 20},
+		{AUDIO_OBJECT_FORMAT_U20LE, AUDIO_ENCODING_ULINEAR_LE, 20},
+		{AUDIO_OBJECT_FORMAT_U20BE, AUDIO_ENCODING_ULINEAR_BE, 20},
+		{AUDIO_OBJECT_FORMAT_S24LE, AUDIO_ENCODING_SLINEAR_LE, 24},
+		{AUDIO_OBJECT_FORMAT_S24BE, AUDIO_ENCODING_SLINEAR_BE, 24},
+		{AUDIO_OBJECT_FORMAT_U24LE, AUDIO_ENCODING_ULINEAR_LE, 24},
+		{AUDIO_OBJECT_FORMAT_U24BE, AUDIO_ENCODING_ULINEAR_BE, 24},
+		{AUDIO_OBJECT_FORMAT_S24_32LE, AUDIO_ENCODING_SLINEAR_LE, 32},
+		{AUDIO_OBJECT_FORMAT_S24_32BE, AUDIO_ENCODING_SLINEAR_BE, 32},
+		{AUDIO_OBJECT_FORMAT_U24_32LE, AUDIO_ENCODING_ULINEAR_LE, 32},
+		{AUDIO_OBJECT_FORMAT_U24_32BE, AUDIO_ENCODING_ULINEAR_BE, 32},
+		{AUDIO_OBJECT_FORMAT_S32LE, AUDIO_ENCODING_SLINEAR_LE, 32},
+		{AUDIO_OBJECT_FORMAT_S32BE, AUDIO_ENCODING_SLINEAR_BE, 32},
+		{AUDIO_OBJECT_FORMAT_U32LE, AUDIO_ENCODING_ULINEAR_LE, 32},
+		{AUDIO_OBJECT_FORMAT_U32BE, AUDIO_ENCODING_ULINEAR_BE, 32},
+		{AUDIO_OBJECT_FORMAT_ADPCM, AUDIO_ENCODING_ADPCM, 8},
+	};
+#define SUNFORMATS (sizeof(aformat_sun_tbl)/sizeof(aformat_sun_tbl[0]))
+	int i;
+	for(i=0; i < SUNFORMATS; i++)
+		if(aformat_sun_tbl[i].audio_object_format == format)
+			break;
+	if(i >= SUNFORMATS)
+		return EINVAL;
+
+	int data;
+	audio_info_t audioinfo;
+	if ((self->fd = open(self->device ? self->device : "/dev/audio", O_WRONLY, 0)) == -1)
+		return errno;
+	AUDIO_INITINFO(&audioinfo);
+	audioinfo.play.sample_rate = rate;
+	audioinfo.play.channels = channels;
+	audioinfo.play.precision = aformat_sun_tbl[i].sun_precision;
+	audioinfo.play.encoding = aformat_sun_tbl[i].sun_format;	
+	if (ioctl(self->fd, AUDIO_SETINFO, &audioinfo) == -1)
+		goto error;
+	return 0;
+error:
+	data = errno;
+	close(self->fd);
+	self->fd = -1;
+	return data;
+}
+
+void
+sun_object_close(struct audio_object *object)
+{
+	struct sun_object *self = to_sun_object(object);
+
+	if (self->fd == -1) {
+		close(self->fd);
+		self->fd = -1;
+	}
+}
+
+void
+sun_object_destroy(struct audio_object *object)
+{
+	struct sun_object *self = to_sun_object(object);
+
+	free(self->device);
+	free(self);
+}
+
+int
+sun_object_drain(struct audio_object *object)
+{
+	struct sun_object *self = to_sun_object(object);
+
+	if (ioctl(self->fd, AUDIO_DRAIN, NULL) == -1)
+		return errno;
+	return 0;
+}
+
+int
+sun_object_flush(struct audio_object *object)
+{
+	struct sun_object *self = to_sun_object(object);
+
+	if (ioctl(self->fd, AUDIO_FLUSH, NULL) == -1)
+		return errno;
+	return 0;
+}
+
+int
+sun_object_write(struct audio_object *object,
+                 const void *data,
+                 size_t bytes)
+{
+	struct sun_object *self = to_sun_object(object);
+
+	if (write(self->fd, data, bytes) == -1)
+		return errno;
+	return 0;
+}
+
+const char *
+sun_object_strerror(struct audio_object *object,
+                    int error)
+{
+	return strerror(error);
+}
+
+struct audio_object *
+create_sun_object(const char *device,
+                  const char *application_name,
+                  const char *description)
+{
+	struct sun_object *self = malloc(sizeof(struct sun_object));
+	if (!self)
+		return NULL;
+
+	self->fd = -1;
+	self->device = device ? strdup(device) : NULL;
+
+	self->vtable.open = sun_object_open;
+	self->vtable.close = sun_object_close;
+	self->vtable.destroy = sun_object_destroy;
+	self->vtable.write = sun_object_write;
+	self->vtable.drain = sun_object_drain;
+	self->vtable.flush = sun_object_flush;
+	self->vtable.strerror = sun_object_strerror;
+
+	return &self->vtable;
+}


### PR DESCRIPTION
This pull request will add support for the native sound system found in NetBSD, Solaris, &c.

More tests can be added to configure.ac for Solaris and Illuminos based systems like Openindiana, but
I don't use any of them and I don't like to add things I  can't test.