### PR TITLE
Feat/build with cmake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,25 +1,46 @@
-name: build
+name: Build
+
 on:
-  push:
-  pull_request:
-    branches: [master]
   workflow_dispatch:
+
 jobs:
   build:
+    name: ${{ matrix.name }}
     strategy:
       fail-fast: false
-      max-parallel: 6
-      matrix:  # TODO: Add all the following OSes...
-        # os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-2025]
-        os: [macos-13, ubuntu-latest, ubuntu-24.04-arm]  # macOS on Intel and Ubuntu builds succeed.
-    runs-on: ${{ matrix.os }}
+      matrix:
+        include:
+          - platform: "macos-latest" # macOS arm64
+            name: "macos-arm64"
+          - platform: "macos-latest" # macOS x86-64
+            name: "macos-x86-64"
+          - platform: "ubuntu-22.04" # Linux x86_64
+            name: "linux-x86-64"
+          - platform: "macos-latest" # Linux arm64
+            name: "linux-x86-64"
+          - platform: "windows-latest" # Windows x86_64
+            name: "windows-x86-64"
+          - platform: "windows-latest" # Windows arm64
+            name: "windows-arm64"
+
+
+    runs-on: ${{ matrix.platform }}
+
     steps:
-      - if: runner.os == 'macOS'
-        run: brew install automake
-      - uses: actions/checkout@v4
-      - shell: bash  # Not pwsh on Windows
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Linux arm64 toolchain
         run: |
-          ./autogen.sh
-          ./configure
-          make
-          sudo make install
+          sudo apt-get install g++-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-g++" >> $GITHUB_ENV
+          echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          echo "CXX=aarch64-linux-gnu-g++" >> $GITHUB_ENV
+        if: matrix.name == 'linux-arm64'
+      - name: Build
+        run: |
+          cmake -B bulid -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=_install
+          cmake --build build --config Release
+          cmake --install build --config Release
+          tree _install
+        shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,11 @@ jobs:
           echo "CC=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
           echo "CXX=aarch64-linux-gnu-g++" >> $GITHUB_ENV
         if: matrix.name == 'linux-arm64'
+
+      - name: Add directxtk for xaudio2
+        run: vcpkg install directxtk[xaudio2redist]:x64-windows
+        if: matrix.platform == 'windows-2022'
+
       - name: Build
         run: |
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=_install ${{ matrix.extra-cmake-args }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,17 +10,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: "macos-latest" # macOS arm64
+          - platform: "macos-14" # macOS arm64
             name: "macos-arm64"
-          - platform: "macos-latest" # macOS x86-64
+          - platform: "macos-14" # macOS x86-64
             name: "macos-x86-64"
           - platform: "ubuntu-22.04" # Linux x86_64
             name: "linux-x86-64"
-          - platform: "macos-latest" # Linux arm64
+          - platform: "ubuntu-22.04" # Linux arm64
             name: "linux-x86-64"
-          - platform: "windows-latest" # Windows x86_64
+          - platform: "windows-2022" # Windows x86_64
             name: "windows-x86-64"
-          - platform: "windows-latest" # Windows arm64
+          - platform: "windows-2022" # Windows arm64
             name: "windows-arm64"
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         if: matrix.name == 'linux-arm64'
       - name: Build
         run: |
-          cmake -B bulid -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=_install
+          cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=_install
           cmake --build build --config Release
           cmake --install build --config Release
           tree _install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
             name: "windows-x86-64"
           - platform: "windows-2022" # Windows arm64
             name: "windows-arm64"
+            extra-cmake-args: "-A ARM64"
 
 
     runs-on: ${{ matrix.platform }}
@@ -39,7 +40,7 @@ jobs:
         if: matrix.name == 'linux-arm64'
       - name: Build
         run: |
-          cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=_install
+          cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=_install ${{ matrix.extra-cmake-args }}
           cmake --build build --config Release
           cmake --install build --config Release
           ls -R _install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
         os: [macos-13, ubuntu-latest, ubuntu-24.04-arm]  # macOS on Intel and Ubuntu builds succeed.
     runs-on: ${{ matrix.os }}
     steps:
+      - if: runner.os == 'macOS'
+        run: brew install automake
       - uses: actions/checkout@v4
       - shell: bash  # Not pwsh on Windows
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: build
+on:
+  push:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:  # TODO: Add all the following OSes...
+        # os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-2025]
+        os: [macos-13, ubuntu-latest, ubuntu-24.04-arm]  # macOS on Intel and Ubuntu builds succeed.
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - shell: bash  # Not pwsh on Windows
+        run: |
+          ./autogen.sh
+          ./configure
+          make
+          sudo make install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,5 +42,5 @@ jobs:
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=_install
           cmake --build build --config Release
           cmake --install build --config Release
-          tree _install
+          ls -R _install
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ autom4te.cache/
 ChangeLog
 compile
 config.h
-config.h.in
 config.h.in~
 config.log
 config.*
@@ -44,3 +43,4 @@ missing
 stamp-h1
 libtool
 ltmain.sh
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ stamp-h1
 libtool
 ltmain.sh
 build/
+_install/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,72 @@
 cmake_minimum_required(VERSION 3.12)
 project(pcaudiolib VERSION 1.3)
 
+# Set the source directory
 set(SRC_DIR "src")
 
 # Add configuration file
 configure_file(config.h.in config.h)
 
+# Include the source directory
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src/include")
+
+# Define options for audio backends
+option(WITH_ALSA "Enable ALSA audio output support" OFF)
+option(WITH_PULSEAUDIO "Enable PulseAudio audio output support" OFF)
+option(WITH_COREAUDIO "Enable CoreAudio audio output support (macOS)" OFF)
+option(WITH_OSS "Enable OSS audio output support" OFF)
+
+# Collect all source files in the src directory
+file(GLOB_RECURSE SOURCES "${SRC_DIR}/*.c")
+
+# Exclude windows.c if not on Windows platform
+if(NOT WIN32)
+    list(FILTER SOURCES EXCLUDE REGEX "windows.c")
+endif()
+
+# ALSA Integration
+if(WITH_ALSA)
+    find_package(ALSA REQUIRED)
+    if(ALSA_FOUND)
+        target_include_directories(${PROJECT_NAME} PRIVATE ${ALSA_INCLUDE_DIRS})
+        target_link_libraries(${PROJECT_NAME} PRIVATE ${ALSA_LIBRARIES})
+        add_definitions(-DHAVE_ALSA_ASOUNDLIB_H)
+        message(STATUS "ALSA support enabled and libraries linked.")
+    else()
+        message(WARNING "ALSA not found. Disabling ALSA support.")
+        set(WITH_ALSA OFF)
+    endif()
+endif()
+
+# Placeholder for other backends (future work)
+if(WITH_PULSEAUDIO)
+    message(STATUS "PulseAudio support is not yet implemented.")
+endif()
+
+if(WITH_COREAUDIO)
+    message(STATUS "CoreAudio support is not yet implemented.")
+endif()
+
+if(WITH_OSS)
+    message(STATUS "OSS support is not yet implemented.")
+endif()
+
+# Add sources and create a static library
+add_library(${PROJECT_NAME} STATIC ${SOURCES})
+
+# Add the configuration header to the target
+target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+
+# Additional settings
+set_target_properties(${PROJECT_NAME} PROPERTIES C_STANDARD 99)
+
+# Output messages for clarity
+message(STATUS "Project: ${PROJECT_NAME}")
+message(STATUS "Version: ${PROJECT_VERSION}")
+message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "CMake Generator: ${CMAKE_GENERATOR}")
+message(STATUS "Options:")
+message(STATUS "  WITH_ALSA: ${WITH_ALSA}")
+message(STATUS "  WITH_PULSEAUDIO: ${WITH_PULSEAUDIO}")
+message(STATUS "  WITH_COREAUDIO: ${WITH_COREAUDIO}")
+message(STATUS "  WITH_OSS: ${WITH_OSS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,10 @@ configure_file(config.h.in config.h)
 # Include the source directory
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src/include")
 
-# Define options for audio backends
-option(WITH_ALSA "Enable ALSA audio output support" OFF)
-option(WITH_PULSEAUDIO "Enable PulseAudio audio output support" OFF)
-option(WITH_COREAUDIO "Enable CoreAudio audio output support (macOS)" ON)
-option(WITH_OSS "Enable OSS audio output support" OFF)
+option(WITH_ALSA "Enable ALSA audio output support" OFF) # Linux - Alsa
+option(WITH_PULSEAUDIO "Enable PulseAudio audio output support" OFF) # Linux - PulseAudio
+option(WITH_COREAUDIO "Enable CoreAudio audio output support (macOS)" ON) # macOS, iOS - CoreAudio
+option(WITH_OSS "Enable OSS audio output support" ON) # Windows - Open Sound System
 
 # Collect all source files in the src directory
 file(GLOB_RECURSE SOURCES "${SRC_DIR}/*.c")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src/include")
 # Define options for audio backends
 option(WITH_ALSA "Enable ALSA audio output support" OFF)
 option(WITH_PULSEAUDIO "Enable PulseAudio audio output support" OFF)
-option(WITH_COREAUDIO "Enable CoreAudio audio output support (macOS)" OFF)
+option(WITH_COREAUDIO "Enable CoreAudio audio output support (macOS)" ON)
 option(WITH_OSS "Enable OSS audio output support" OFF)
 
 # Collect all source files in the src directory
@@ -26,19 +26,19 @@ if(NOT WIN32)
     list(FILTER SOURCES EXCLUDE REGEX "windows.c")
 endif()
 
-if(NOT WITH_ALSA)
+if(NOT WITH_ALSA OR NOT UNIX)
     list(FILTER SOURCES EXCLUDE REGEX "alsa.c")
 endif()
 
-if(NOT WITH_COREAUDIO)
+if(NOT WITH_COREAUDIO OR NOT APPLE)
     list(FILTER SOURCES EXCLUDE REGEX "coreaudio.c")
 endif()
 
-if(NOT WITH_OSS)
+if(NOT WITH_OSS OR NOT UNIX)
     list(FILTER SOURCES EXCLUDE REGEX "oss.c")
 endif()
 
-if(NOT WITH_PULSEAUDIO)
+if(NOT WITH_PULSEAUDIO OR NOT UNIX)
     list(FILTER SOURCES EXCLUDE REGEX "pulseaudio.c")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.12)
+project(pcaudiolib VERSION 1.3)
+
+set(SRC_DIR "src")
+
+# Add configuration file
+configure_file(config.h.in config.h)
+
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src/include")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if(WITH_OSS)
 endif()
 
 # Add sources and create a static library
-add_library(${PROJECT_NAME} STATIC ${SOURCES})
+add_library(${PROJECT_NAME} SHARED ${SOURCES})
 
 # Add the configuration header to the target
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
@@ -70,3 +70,10 @@ message(STATUS "  WITH_ALSA: ${WITH_ALSA}")
 message(STATUS "  WITH_PULSEAUDIO: ${WITH_PULSEAUDIO}")
 message(STATUS "  WITH_COREAUDIO: ${WITH_COREAUDIO}")
 message(STATUS "  WITH_OSS: ${WITH_OSS}")
+
+
+install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/include/ DESTINATION include)
+
+# cmake -B build . -DCMAKE_INSTALL_PREFIX=_install 
+# cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,27 @@ option(WITH_OSS "Enable OSS audio output support" OFF)
 # Collect all source files in the src directory
 file(GLOB_RECURSE SOURCES "${SRC_DIR}/*.c")
 
-# Exclude windows.c if not on Windows platform
+
+# Exclude platform-specific files based on the OS
+
 if(NOT WIN32)
     list(FILTER SOURCES EXCLUDE REGEX "windows.c")
+endif()
+
+if(NOT WITH_ALSA)
+    list(FILTER SOURCES EXCLUDE REGEX "alsa.c")
+endif()
+
+if(NOT WITH_COREAUDIO)
+    list(FILTER SOURCES EXCLUDE REGEX "coreaudio.c")
+endif()
+
+if(NOT WITH_OSS)
+    list(FILTER SOURCES EXCLUDE REGEX "oss.c")
+endif()
+
+if(NOT WITH_PULSEAUDIO)
+    list(FILTER SOURCES EXCLUDE REGEX "pulseaudio.c")
 endif()
 
 # ALSA Integration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,19 @@ if(NOT WITH_PULSEAUDIO OR NOT UNIX)
     list(FILTER SOURCES EXCLUDE REGEX "pulseaudio.c")
 endif()
 
+# Oss Integration
+if(WITH_OSS AND WIN32)
+    list(FILTER SOURCES EXCLUDE REGEX "oss.c")
+    # See https://github.com/microsoft/DirectXTK/wiki/Audio#using-the-vcpkg-c-library-manager
+    target_compile_definitions(${PROJECT_NAME} PRIVATE USING_XAUDIO2_REDIST)
+    if (NOT EXISTS "${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/xaudio2redist/xaudio2.h")
+        message(FATAL_ERROR "VCPKG port 'xaudio2redist' required for DirectX Tool Kit for Audio on Windows 7")
+    endif()
+    target_include_directories(${PROJECT_NAME} PRIVATE ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/xaudio2redist)
+    target_link_directories(${PROJECT_NAME} PRIVATE ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib)
+    target_link_libraries(${PROJECT_NAME} PRIVATE xaudio2_9redist.lib)
+endif()
+
 # ALSA Integration
 if(WITH_ALSA)
     find_package(ALSA REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 
 if(NOT WITH_COREAUDIO OR NOT APPLE)
     list(FILTER SOURCES EXCLUDE REGEX "coreaudio.c")
+    list(FILTER SOURCES EXCLUDE REGEX "TPCircularBuffer")
 endif()
 
 if(NOT WITH_OSS OR NOT UNIX)

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,4 @@
+#cmakedefine WITH_ALSA 0
+#cmakedefine WITH_PULSEAUDIO 0
+#cmakedefine WITH_COREAUDIO 0
+#cmakedefine WITH_OSS 0


### PR DESCRIPTION
Add CMake configuration and CI
It's best to squash the commits when merging (in the merge button in Github UI there's option)

CI (Success): https://github.com/thewh1teagle/pcaudiolib/actions/runs/12961423582

Build successfully on macOS (arm/amd64), Linux(arm,amd64), Windows (amd64)
Backends: Alsa, PulseAudio, CoreAudio, OSS
Linking with espeak: Linux (dynamic), macOS (static,dynamic), Windows (static,dynamic)

Related:

- https://github.com/thewh1teagle/pcaudiolib/issues/1
- https://github.com/espeak-ng/pcaudiolib/pull/31
- https://github.com/espeak-ng/pcaudiolib/issues/22
- https://github.com/microsoft/DirectXTK/issues/524
- https://stackoverflow.com/a/1492189/13393388 (very important on macOS)


Build instructions with espeak-ng for all platforms


<details>

macOS 

```console
# Build shared pcaudiolib
git clone https://github.com/thewh1teagle/pcaudiolib -b feat/build-with-cmake
cd pcaudiolib
cmake -B build -DCMAKE_INSTALL_PREFIX=_install -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build --config Release
cmake --install build
ls -R _install
export PCAUDIO_PATH=$(pwd)/_install

# Dynamic link pcaudiolib
git clone https://github.com/espeak-ng/espeak-ng -b 1.52.0
cd espeak-ng
cmake -B build -DCMAKE_INSTALL_PREFIX=_install -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$PCAUDIO_PATH
cmake --build build --config Release
cmake --install build
ls -R _install
cp $PCAUDIO_PATH/lib/*.dylib _install/lib     
./_install/bin/espeak-ng hello # speaking works
```

Windows

```console
git clone https://github.com/thewh1teagle/pcaudiolib -b feat/build-with-cmake
cd pcaudiolib
cmake -B build -DCMAKE_INSTALL_PREFIX=_install -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
cmake --build build --config Release
cmake --install build
ls -R _install
$env:PCAUDIO_PATH="$pwd\_install"

# Static link pcaudiolib
git clone https://github.com/espeak-ng/espeak-ng -b 1.52.0
cd espeak-ng
ls $env:PCAUDIO_PATH
cmake -B build -DCMAKE_INSTALL_PREFIX=_install -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$env:PCAUDIO_PATH" # Or absolute path
cmake --build build --config Release
cmake --install build
./_install/bin/espeak-ng hello # speaking works
```

Linux

```console
# Build shared pcaudiolib
sudo apt-get install libpulse-dev -y
git clone https://github.com/thewh1teagle/pcaudiolib -b feat/build-with-cmake
cd pcaudiolib
rm -rf build _install
cmake -B build -DCMAKE_INSTALL_PREFIX=_install -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build --config Release
cmake --install build
ldd _install/lib/*.so
ls -R _install
export PCAUDIO_PATH=$(pwd)/_install

# Dynamic link pcaudiolib
git clone https://github.com/espeak-ng/espeak-ng -b 1.52.0
cd espeak-ng
rm -rf build _install
cmake -B build -DCMAKE_INSTALL_PREFIX=_install -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$PCAUDIO_PATH"
cmake --build build --config Release
cmake --install build
ls -R _install
cp $PCAUDIO_PATH/lib/*.so _install/lib     
./_install/bin/espeak-ng hello # speaking works
```

</details>


Notes:

To build espeak-ng on macOS and link it statically, these changes are required in espeak-ng near each `add_executable` call:

```cmake
target_link_libraries(espeak-ng-bin PRIVATE "-framework CoreAudio" "-framework AudioToolbox" "-framework AudioUnit") # src/CMakeLists.txt
target_link_libraries(test_${_test_name} PRIVATE "-framework CoreAudio" "-framework AudioToolbox" "-framework AudioUnit") # ...
```

Optional improvements in espeak:

- https://stackoverflow.com/questions/66017579/static-linking-of-linux-audio-libraries
- https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/1089