### PR TITLE
Fill out xaudio2_object_flush and fix MinGW64 build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,8 @@ src_libpcaudio_la_LDFLAGS = -version-info $(LIBPCAUDIO_VERSION) \
 	${ALSA_LIBS} \
 	${PULSEAUDIO_LIBS} \
 	${QSA_LIBS} \
-	${COREAUDIO_LIBS}
+	${COREAUDIO_LIBS} \
+	${XAUDIO2_LIBS}
 
 src_libpcaudio_la_CFLAGS = ${AM_CFLAGS} \
 	${ALSA_CFLAGS} \
@@ -65,18 +66,15 @@ src_libpcaudio_la_CFLAGS = ${AM_CFLAGS} \
 	${COREAUDIO_CFLAGS}
 
 src_libpcaudio_la_SOURCES = \
-	src/alsa.c \
-	src/qsa.c \
-	src/oss.c \
-	src/pulseaudio.c \
 	src/audio_priv.h \
 	src/audio.c
 
 # Windows audio support
-EXTRA_DIST += \
+if HAVE_XAUDIO2
+src_libpcaudio_la_SOURCES += \
 	src/windows.c \
 	src/xaudio2.cpp
-
+else
 # Mac OSX audio support
 if HAVE_COREAUDIO
 src_libpcaudio_la_SOURCES += \
@@ -89,4 +87,11 @@ src_libpcaudio_la_SOURCES += \
 EXTRA_DIST += \
 	src/TPCircularBuffer/README.markdown \
 	src/TPCircularBuffer/TPCircularBuffer.podspec
+else
+src_libpcaudio_la_SOURCES += \
+	src/alsa.c \
+	src/qsa.c \
+	src/oss.c \
+	src/pulseaudio.c
+endif
 endif

--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ and install it using:
 
 	sudo make install
 
+### Windows MinGW64
+
+You can build on Windows MinGW64 like this:
+
+    ./autogen.sh
+    ./configure --prefix=/mingw64
+    sed -i.bak -e "s/\(allow_undefined=\)yes/\1no/" libtool
+    make LIBTOOLFLAGS=-v
+
 ## Bugs
 
 Report bugs to the [pcaudiolib issues](https://github.com/espeak-ng/pcaudiolib/issues)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ You can build on Windows MinGW64 like this:
 
     ./autogen.sh
     ./configure --prefix=/mingw64
-    sed -i.bak -e "s/\(allow_undefined=\)yes/\1no/" libtool
     make LIBTOOLFLAGS=-v
 
 ## Bugs

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,7 @@ dnl Program checks.
 dnl ================================================================
 
 AC_PROG_CC
+AC_PROG_CXX
 AC_PROG_MAKE_SET
 AC_PROG_LIBTOOL
 
@@ -93,6 +94,33 @@ fi
 AC_SUBST(QSA_LIBS)
 
 dnl ================================================================
+dnl xaudio2 checks.
+dnl ================================================================
+
+AC_ARG_WITH([xaudio2],
+    [AS_HELP_STRING([--with-xaudio2], [support for xaudio2 audio output on Windows @<:@default=yes@:>@])],
+    [])
+
+if test "$with_xaudio2" = "no";then
+    echo "Disabling xaudio2 audio output support"
+    have_xaudio2=no
+else
+    case "$host" in
+      *-*-mingw*)
+        have_xaudio2=yes
+        XAUDIO2_LIBS="-lole32 -lxaudio2_9"
+        AC_DEFINE(HAVE_XAUDIO2_H, [], [Do we have xaudio?])
+        ;;
+    *)
+        have_xaudio2=no
+        ;;
+    esac
+fi
+
+AC_SUBST(XAUDIO2_LIBS)
+AM_CONDITIONAL([HAVE_XAUDIO2], [test "x${have_xaudio2}" = "xyes"])
+
+dnl ================================================================
 dnl coreaudio checks.
 dnl ================================================================
 
@@ -160,6 +188,7 @@ AC_MSG_NOTICE([
 	PulseAudio support:            ${have_pulseaudio}
 	ALSA support:                  ${have_alsa}
 	QSA support:                   ${have_qsa}
+	Xaudio2 support:               ${have_xaudio2}
 	Coreaudio support:             ${have_coreaudio}
 	OSS support:                   ${have_oss}
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -170,6 +170,21 @@ else
 fi
 
 dnl ================================================================
+dnl Patch libtool if mingw64
+dnl ================================================================
+
+AC_CONFIG_COMMANDS([fix-libtool], [
+  case "$host_os" in
+    mingw32*)
+      if test -f libtool; then
+        echo "Patching libtool for mingw64: setting allow_undefined=no"
+        sed -i.bak -e 's/\(allow_undefined=\)yes/\1no/' libtool
+      fi
+      ;;
+  esac
+])
+
+dnl ================================================================
 dnl Generate output.
 dnl ================================================================
 

--- a/src/windows.c
+++ b/src/windows.c
@@ -84,7 +84,7 @@ windows_hresult_strerror(struct audio_object *object,
 {
 	char *msg = NULL;
 	DWORD result = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-		NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), &msg, 256, NULL);
+		NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), msg, 256, NULL);
 	if (!result)
 		return NULL;
 

--- a/src/xaudio2.cpp
+++ b/src/xaudio2.cpp
@@ -199,7 +199,7 @@ create_xaudio2_object(const char *device,
                       const char *application_name,
                       const char *description)
 {
-	CoInitialize(NULL);
+	CoInitializeEx(NULL, COINIT_MULTITHREADED);
 
 	IXAudio2 *audio = NULL;
 	HRESULT hr = XAudio2Create(&audio, 0, XAUDIO2_DEFAULT_PROCESSOR);


### PR DESCRIPTION
This PR makes a few changes in configure.am and Makefile.am to allow the build to complete successfully on MinGW64. 

It populates the xaudio2_object_flush function to enable cancelling of a playing sound. 

A test program is here: https://github.com/mcarans/AudioTest/blob/main/testpcaudiolib.cpp. It loads a long wav and then using pcaudiolib, plays it then cancels it after 2 seconds. It works fine on Windows MinGW64.

For this cancellation to work in espeak-ng, this PR that performs the audio_object_flush step before fifo_stop is required otherwise the playing speech is not cancelled at all: https://github.com/espeak-ng/espeak-ng/pull/2288

This library along with espeak-ng have been tested within the [Oolite](https://github.com/OoliteProject/oolite) game on Windows MinGW64 and the ability to cancel playing speech works well in the game (and is essential for smooth play).

The updated pcaudiolib was also tested on Ubuntu to ensure nothing has been broken.

